### PR TITLE
Ignore OS generated files 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,5 @@
 node_modules/
+
+# OS generated files
+.DS_Store
+Thumbs.db


### PR DESCRIPTION
### Status
PENDING REVIEW

### What does this PR accomplish?
- Expands `.gitignore` with the very basic set of the most commonly OS generated files (MacOS and Windows)

### Why?
As more and more users learn about this project and start contributing, the chances are at least small percentage of them will accidentally commit some of these generated files. Yes, it's easy to address that in the code review but it's better to nip it in the bud.

### Potential next steps
- We could expand the set of ignored files and include IDE specific files, for example. We can brainstorm the shape of the minimally sufficient and efficient `.gitignore` in this PR.