### PR TITLE
Control port with constant (and environment variable) + notice log when starting

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ node server.js
 ```
 
 By default, the server will run on `localhost` at port `8034`, and thus the app will be available in your browser via `http://localhost:8034`.
+However, you have the ability to control the port through the environment variable `HTTP_SERVER_PORT`.
 
 ## License
 

--- a/server.js
+++ b/server.js
@@ -94,6 +94,7 @@ var staticServer = new nodeStaticAlias.Server(STATIC_DIR,{
 
 httpServer.listen(8034);
 
+console.log("The app is running on http://localhost:8034");
 
 // *************************************
 

--- a/server.js
+++ b/server.js
@@ -93,9 +93,9 @@ var staticServer = new nodeStaticAlias.Server(STATIC_DIR,{
 	],
 });
 
-httpServer.listen(PORT);
-
-console.log(`The app is running on http://localhost:${PORT}`);
+httpServer.listen(PORT, () => {
+	console.log(`The app is running on http://localhost:${PORT}`);
+});
 
 // *************************************
 

--- a/server.js
+++ b/server.js
@@ -48,6 +48,7 @@ var CSPHeader = {
 const STATIC_DIR = path.join(__dirname,"web");
 const DEV = true;
 const CACHE_FILES = false;
+const PORT = 8034;
 
 var staticServer = new nodeStaticAlias.Server(STATIC_DIR,{
 	serverInfo: "YouPeriod",
@@ -92,9 +93,9 @@ var staticServer = new nodeStaticAlias.Server(STATIC_DIR,{
 	],
 });
 
-httpServer.listen(8034);
+httpServer.listen(PORT);
 
-console.log("The app is running on http://localhost:8034");
+console.log(`The app is running on http://localhost:${PORT}`);
 
 // *************************************
 

--- a/server.js
+++ b/server.js
@@ -48,7 +48,7 @@ var CSPHeader = {
 const STATIC_DIR = path.join(__dirname,"web");
 const DEV = true;
 const CACHE_FILES = false;
-const PORT = process.env.YOUPERIOD_PORT || 8034;
+const PORT = process.env.HTTP_SERVER_PORT || 8034;
 
 var staticServer = new nodeStaticAlias.Server(STATIC_DIR,{
 	serverInfo: "YouPeriod",

--- a/server.js
+++ b/server.js
@@ -48,7 +48,7 @@ var CSPHeader = {
 const STATIC_DIR = path.join(__dirname,"web");
 const DEV = true;
 const CACHE_FILES = false;
-const PORT = 8034;
+const PORT = process.env.YOUPERIOD_PORT || 8034;
 
 var staticServer = new nodeStaticAlias.Server(STATIC_DIR,{
 	serverInfo: "YouPeriod",


### PR DESCRIPTION
### Status
PENDING REVIEW

### What does this PR accomplish?
- Adds the app link in the local dev mode (useful because in most modern terminals you can click on it, which opens the default browser on your machine)
- Stores the `PORT` in a const

Here are some screenshots from iTerm:

Before
![image](https://user-images.githubusercontent.com/31325167/177191339-d4b6e562-4bdd-4997-91d9-3e48343b0d5c.png)

Now
![image](https://user-images.githubusercontent.com/31325167/177191416-2bbd1e87-7d41-4d7e-bd91-a37f61334e53.png)

### How to test?
1. clone repo
2. `npm install`
3. `node server.js`
4. You should see the string "The app is running on http://localhost:8034" with a link that will most likely be clickable

### Why?
Tbh, I was a bit confused during the first app run and was kept waiting for something to happen only to realize the app was already running 😅

This simple change should help developers and remove confusion.

### Potential next steps
- Set the port as ENV