### PR TITLE
More accurate alert for insufficient passphrase length (letters -> characters)

### DIFF
--- a/SPECS.md
+++ b/SPECS.md
@@ -6,7 +6,7 @@ This application is written with HTML + CSS + JS and under the hood use NodeJs h
 When the end user hit the homepage there are some information to fill
 
 -   profile name/description - _at least 2 letters long_
--   secret phrase (with confirmation check) - _at least 12 letters long_
+-   secret phrase (with confirmation check) - _at least 12 characters long_
 
 with these info the application will create an unique local profile into IndexedDB database called `keyval-store`.<br>
 

--- a/web/js/main.js
+++ b/web/js/main.js
@@ -150,7 +150,7 @@ async function onCreateProfile(evt) {
 			return false;
 		}
 		if (passphraseEl.value.length < 12) {
-			alert("Please enter a passphrase at least 12 letters long.");
+			alert("Please enter a passphrase at least 12 characters long.");
 			return false;
 		}
 		if (passphraseEl.value !== confirmPassphraseEl.value) {


### PR DESCRIPTION
### Status
PENDING REVIEW

### What does this PR accomplish?
- Uses "characters" instead of "letters" to describe the minimum passphrase length in the related alert
- Updates the documentation accordingly

> **Note**
> Although it might seem like nitpicking, the distinction between letters and characters is quite important when it comes to the password complexity.

