### PR TITLE
add auth-worker check & specific CSP for it

### DIFF
--- a/server.js
+++ b/server.js
@@ -149,6 +149,34 @@ async function onRequest(req,res) {
 			}
 		}
 
+		// check if the request url is using "auth-worker.js"
+		// when I just looked for "auth-worker.js" it didn't seem to actually find the url
+		if (req.url == "/js/auth-worker.js") {
+			res.writeHead(200, {
+				...HSTSHeader,
+				"Content-Security-Policy":
+			[
+				`default-src ${[
+					"'self'",
+				].join(" ")};`,
+	
+				`style-src ${[
+					"'self'",
+					"'unsafe-inline'",
+				].join(" ")};`,
+	
+				`script-src ${[
+					"'self'",
+					"wasm-unsafe-eval",
+				].join(" ")};`,
+	
+				`connect-src ${[
+					"'none'",
+				].join(" ")};`
+			].join(" ") }
+			)
+		}
+
 		// handle all other static files
 		staticServer.serve(req,res,async function onStaticComplete(err){
 			if (err) {

--- a/server.js
+++ b/server.js
@@ -24,15 +24,6 @@ var noSniffHeader = {
 var CSPHeader = {
 	"Content-Security-Policy":
 		[
-			`default-src ${[
-				"'self'",
-			].join(" ")};`,
-
-			`style-src ${[
-				"'self'",
-				"'unsafe-inline'",
-			].join(" ")};`,
-
 			`script-src ${[
 				"'self'",
 				// inline <script> tag for re-computing the vw/vh units

--- a/server.js
+++ b/server.js
@@ -160,10 +160,6 @@ async function onRequest(req,res) {
 					"'self'",
 					"wasm-unsafe-eval",
 				].join(" ")};`,
-	
-				`connect-src ${[
-					"'none'",
-				].join(" ")};`
 			].join(" ") }
 			)
 		}


### PR DESCRIPTION
#### Changes
<!-- Please include a summary of the change and which issue is fixed. --> 
<!-- Please also include relevant motivation and context. -->
<!-- List any dependencies that are required for this change. -->

As the issue stated around [line 152 in the server.js](https://github.com/bbland1/youperiod.app/blob/2cc334d4d115472c53f6a03528516a7ee8c4b223/server.js#L152) I added an If statement that checks the request url to see if it uses the worker (auth-worker). If the request does then using `res.writehead()` to pass the CSP policy on the response that uses `was-unsafe-eval` and `self` into the `script-src` portion of the CSP. 

I ran the code without the additional lines and with and didn't get any errors within dev tools or the editor, as well as viewing the response headers and each seem to have gone well with no issues currently being seen.


Fixes #67 

#### Type of change
<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)

#### Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
